### PR TITLE
s6-overlay-suexec v3 compatibility for HA 2022.6+

### DIFF
--- a/uhubctl/config.json
+++ b/uhubctl/config.json
@@ -10,6 +10,7 @@
         "armv7",
         "aarch64"
     ],
+    "init": false,
     "startup": "application",
     "services": [
         "mqtt:need"

--- a/uhubctl/run.sh
+++ b/uhubctl/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 set +eu
 
 # Check if the log level configuration option exists


### PR DESCRIPTION
“init: false” in config.json fixes the fatal add-on error:
  s6-overlay-suexec: fatal: can only run as pid 1

“with-contenv” restores SUPERVISOR_TOKEN etc, fixing supervisor errors:
  [supervisor.api.middleware.security] Invalid token for access /addons/self/options/config
  [supervisor.api.middleware.security] Invalid token for access /services/mqtt

Cf. https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/
and https://github.com/just-containers/s6-overlay/blob/master/README.md,
respectively; plus
https://www.home-assistant.io/blog/2022/06/01/release-20226/#breaking-changes.